### PR TITLE
Rework WebAuthn project layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -246,147 +246,163 @@
                             </li>
                         </ul>
                     </div>
-                    <div class="project-section">
-                        <h4>Simple Authentication</h4>
-                        <figure class="project-figure project-figure-left">
+                    <div class="project-section project-section-split">
+                        <div class="project-section-text">
+                            <h4>Simple Authentication</h4>
+                            <p>
+                                The simple tab supplies a minimal form: users enter a username (with a helper button to randomize it),
+                                initiate registration or authentication, and watch the inline status and spinner update through each
+                                step.
+                            </p>
+                            <p>
+                                Behind the scenes, <code>simpleRegister</code> calls the server for credential creation options,
+                                normalizes requested extensions, invokes WebAuthn <code>create</code>, and posts the resulting credential
+                                back to <code>/api/register/complete</code>, reporting success, randomizing the username, and refreshing
+                                the saved credential cache. Similarly, <code>simpleAuthenticate</code> fetches assertion options, calls
+                                WebAuthn <code>get</code>, and submits the assertion to <code>/api/authenticate/complete</code>, mapping
+                                common WebAuthn errors to readable status messages.
+                            </p>
+                        </div>
+                        <figure class="project-figure">
                             <img src="images/webauthn-project/simple-authentication.png" alt="Simple authentication tab with register and authenticate controls">
                         </figure>
-                        <p>
-                            The simple tab supplies a minimal form: users enter a username (with a helper button to randomize it),
-                            initiate registration or authentication, and watch the inline status and spinner update through each
-                            step.
-                        </p>
-                        <p>
-                            Behind the scenes, <code>simpleRegister</code> calls the server for credential creation options,
-                            normalizes requested extensions, invokes WebAuthn <code>create</code>, and posts the resulting credential
-                            back to <code>/api/register/complete</code>, reporting success, randomizing the username, and refreshing
-                            the saved credential cache. Similarly, <code>simpleAuthenticate</code> fetches assertion options, calls
-                            WebAuthn <code>get</code>, and submits the assertion to <code>/api/authenticate/complete</code>, mapping
-                            common WebAuthn errors to readable status messages.
-                        </p>
                     </div>
-                    <div class="project-section">
-                        <h4>Advanced Authentication</h4>
-                        <figure class="project-figure project-figure-right">
-                            <img src="images/webauthn-project/advanced-authentication.png" alt="Advanced authentication tab with expandable panels and configuration options">
-                        </figure>
-                        <p>
-                            The advanced tab splits into registration and authentication sub-tabs, each containing expandable
-                            panels for user identity, authenticator selection, other options, and extensions with bilingual tooltips
-                            that explain every parameter choice. A dedicated JSON editor column mirrors the form state, offers
-                            expand, save, and reset controls, and keeps the textarea optimized for manual edits. On the right, a
-                            binary-format selector and saved credential panel provide quick format conversions and bulk deletion
-                            capabilities. When the page loads, helper scripts randomize IDs and challenges, seed large-blob and PRF
-                            fields, pull saved credentials, and wire input events so that any change updates the JSON representation
-                            automatically.
-                        </p>
-                        <p>
-                            During advanced registration, the JSON editor’s payload is validated, optional extensions such as
-                            <code>minPinLength</code> are merged in, WebAuthn <code>create</code> is invoked, and the response is
-                            posted to <code>/api/advanced/register/complete</code>; success triggers modal details, status feedback,
-                            and a saved credential refresh, while failures surface likely incompatibilities (e.g., unsupported
-                            algorithms or extensions).
-                        </p>
-                        <figure class="project-figure project-figure-left">
-                            <img src="images/webauthn-project/advanced-authentication-json-editor.png" alt="Advanced authentication JSON editor synchronized with the configuration form">
-                        </figure>
-                        <p>
-                            Advanced authentication mirrors that flow by validating request JSON, enforcing hint rules, performing
-                            WebAuthn <code>get</code>, and submitting the result to <code>/api/advanced/authenticate/complete</code>,
-                            again surfacing human-friendly outcomes or guidance when no suitable credential is found.
-                        </p>
+                    <div class="project-section project-section-split">
+                        <div class="project-section-text">
+                            <h4>Advanced Authentication</h4>
+                            <p>
+                                The advanced tab splits into registration and authentication sub-tabs, each containing expandable
+                                panels for user identity, authenticator selection, other options, and extensions with bilingual tooltips
+                                that explain every parameter choice. A dedicated JSON editor column mirrors the form state, offers
+                                expand, save, and reset controls, and keeps the textarea optimized for manual edits. On the right, a
+                                binary-format selector and saved credential panel provide quick format conversions and bulk deletion
+                                capabilities. When the page loads, helper scripts randomize IDs and challenges, seed large-blob and PRF
+                                fields, pull saved credentials, and wire input events so that any change updates the JSON representation
+                                automatically.
+                            </p>
+                            <p>
+                                During advanced registration, the JSON editor’s payload is validated, optional extensions such as
+                                <code>minPinLength</code> are merged in, WebAuthn <code>create</code> is invoked, and the response is
+                                posted to <code>/api/advanced/register/complete</code>; success triggers modal details, status feedback,
+                                and a saved credential refresh, while failures surface likely incompatibilities (e.g., unsupported
+                                algorithms or extensions).
+                            </p>
+                            <p>
+                                Advanced authentication mirrors that flow by validating request JSON, enforcing hint rules, performing
+                                WebAuthn <code>get</code>, and submitting the result to <code>/api/advanced/authenticate/complete</code>,
+                                again surfacing human-friendly outcomes or guidance when no suitable credential is found.
+                            </p>
+                        </div>
+                        <div class="project-section-media">
+                            <figure class="project-figure">
+                                <img src="images/webauthn-project/advanced-authentication.png" alt="Advanced authentication tab with expandable panels and configuration options">
+                            </figure>
+                            <figure class="project-figure">
+                                <img src="images/webauthn-project/advanced-authentication-json-editor.png" alt="Advanced authentication JSON editor synchronized with the configuration form">
+                            </figure>
+                        </div>
                     </div>
-                    <div class="project-section">
-                        <h4>Saved Credentials and Credential Details</h4>
-                        <figure class="project-figure project-figure-right">
-                            <img src="images/webauthn-project/credential-details-page-1.png" alt="Saved credentials list with badges highlighting discoverable and PQC traits">
-                        </figure>
-                        <p>
-                            Saved credentials are fetched from <code>/api/credentials</code>, normalized with derived hex
-                            identifiers, and stored in client state before rendering the panel or updating JSON previews. Each list
-                            entry highlights discoverable, large-blob, or PQC traits, supports keyboard activation of the detail
-                            modal, and exposes a delete shortcut that targets the correct server record. Server-backed delete and
-                            clear-all handlers confirm intent, post to <code>/api/deletepub</code> or <code>/api/credentials</code>,
-                            and update both UI and status messaging when the operations complete.
-                        </p>
-                        <p>
-                            The credential detail modal itself is defined in HTML but populated entirely by JavaScript at runtime.
-                            The renderer gathers user information, user handle encodings, and credential ID encodings; it evaluates
-                            stored attestation summaries and flags to describe discoverability, large blob support, minPinLength,
-                            attestation checks, authenticator data bits, signature counters, and any client extension outputs
-                            captured during registration. Public key information is annotated with COSE key type, ML-DSA parameter
-                            sets, and base64/base64url/hex encodings to aid PQC inspection.
-                        </p>
-                        <figure class="project-figure project-figure-left">
-                            <img src="images/webauthn-project/credential-details-page-2.png" alt="Credential detail modal with attestation summaries and authenticator flags">
-                        </figure>
-                        <p>
-                            When present, archived registration details are embedded for deeper comparison, and an AAGUID "Info"
-                            button appears for root-verified attestations; clicking it triggers an asynchronous lookup that can
-                            wait for metadata to load, surfaces status updates in the modal, and then closes the modal once the
-                            related authenticator entry is highlighted in the MDS table.
-                        </p>
+                    <div class="project-section project-section-split">
+                        <div class="project-section-text">
+                            <h4>Saved Credentials and Credential Details</h4>
+                            <p>
+                                Saved credentials are fetched from <code>/api/credentials</code>, normalized with derived hex
+                                identifiers, and stored in client state before rendering the panel or updating JSON previews. Each list
+                                entry highlights discoverable, large-blob, or PQC traits, supports keyboard activation of the detail
+                                modal, and exposes a delete shortcut that targets the correct server record. Server-backed delete and
+                                clear-all handlers confirm intent, post to <code>/api/deletepub</code> or <code>/api/credentials</code>,
+                                and update both UI and status messaging when the operations complete.
+                            </p>
+                            <p>
+                                The credential detail modal itself is defined in HTML but populated entirely by JavaScript at runtime.
+                                The renderer gathers user information, user handle encodings, and credential ID encodings; it evaluates
+                                stored attestation summaries and flags to describe discoverability, large blob support, minPinLength,
+                                attestation checks, authenticator data bits, signature counters, and any client extension outputs
+                                captured during registration. Public key information is annotated with COSE key type, ML-DSA parameter
+                                sets, and base64/base64url/hex encodings to aid PQC inspection.
+                            </p>
+                            <p>
+                                When present, archived registration details are embedded for deeper comparison, and an AAGUID "Info"
+                                button appears for root-verified attestations; clicking it triggers an asynchronous lookup that can
+                                wait for metadata to load, surfaces status updates in the modal, and then closes the modal once the
+                                related authenticator entry is highlighted in the MDS table.
+                            </p>
+                        </div>
+                        <div class="project-section-media">
+                            <figure class="project-figure">
+                                <img src="images/webauthn-project/credential-details-page-1.png" alt="Saved credentials list with badges highlighting discoverable and PQC traits">
+                            </figure>
+                            <figure class="project-figure">
+                                <img src="images/webauthn-project/credential-details-page-2.png" alt="Credential detail modal with attestation summaries and authenticator flags">
+                            </figure>
+                        </div>
                     </div>
-                    <div class="project-section">
-                        <h4>Decoder</h4>
-                        <figure class="project-figure project-figure-right">
+                    <div class="project-section project-section-split">
+                        <div class="project-section-text">
+                            <h4>Decoder</h4>
+                            <p>
+                                The decoder tab enumerates all recognized WebAuthn payload formats&mdash;covering credential JSON, CBOR
+                                attestation objects, authenticator data, client data, PEM or DER certificates, general JSON, and CBOR
+                                blobs&mdash;and notes that binary inputs may be base64, base64url, or hex (with colon tolerance for hex).
+                                Submissions post the pasted payload to <code>/api/decode</code>, clear prior output, display progress, and
+                                then either render a structured summary with status chips and sectioned data or report parsing errors;
+                                users can also toggle a raw JSON textarea view for deeper inspection or hide it to focus on the summary.
+                            </p>
+                        </div>
+                        <figure class="project-figure">
                             <img src="images/webauthn-project/decoder.png" alt="Decoder tab showing parsed WebAuthn payloads and raw output toggles">
                         </figure>
-                        <p>
-                            The decoder tab enumerates all recognized WebAuthn payload formats&mdash;covering credential JSON, CBOR
-                            attestation objects, authenticator data, client data, PEM or DER certificates, general JSON, and CBOR
-                            blobs&mdash;and notes that binary inputs may be base64, base64url, or hex (with colon tolerance for hex).
-                            Submissions post the pasted payload to <code>/api/decode</code>, clear prior output, display progress, and
-                            then either render a structured summary with status chips and sectioned data or report parsing errors;
-                            users can also toggle a raw JSON textarea view for deeper inspection or hide it to focus on the summary.
-                        </p>
                     </div>
-                    <div class="project-section">
-                        <h4>FIDO MDS Explorer</h4>
-                        <figure class="project-figure project-figure-left">
+                    <div class="project-section project-section-split">
+                        <div class="project-section-text">
+                            <h4>FIDO MDS Explorer</h4>
+                            <p>
+                                The MDS tab features an update button, live entry counters, a sortable and filterable table, and modals
+                                dedicated to certificate decoding and authenticator detail browsing. When the page loads, any
+                                server-provided metadata snapshot is exposed through a hidden bootstrap element so the client can
+                                initialize without an extra network call.
+                            </p>
+                            <p>
+                                The <code>loadMdsData</code> routine checks for forced reloads, applies bootstrap or cached payloads when
+                                available, and otherwise fetches the metadata BLOB with cache-aware options while handling missing files,
+                                clearing caches, and resetting UI state appropriately. Once metadata entries arrive, they are
+                                transformed, indexed by AAGUID, used to populate filter dropdowns, annotated with next-update deadlines,
+                                and reported through the status banner before column resizing is re-enabled.
+                            </p>
+                            <p>
+                                Update requests toggle button states, post to <code>/api/mds/update</code>, interpret whether a reload is
+                                required, and either re-fetch the BLOB or inform the user when data is already current (highlighting
+                                overdue deadlines when necessary). When a credential detail’s AAGUID info button is pressed, the helper
+                                switches to the MDS tab, waits for metadata to load if needed, and then asks the explorer to locate and
+                                highlight the relevant authenticator; the highlighting routine normalizes AAGUIDs, resets filters,
+                                scrolls smoothly to the matching row, and returns whether the focus succeeded.
+                            </p>
+                        </div>
+                        <figure class="project-figure">
                             <img src="images/webauthn-project/fido-mds-authenticators-page.png" alt="FIDO MDS explorer with authenticator table and filter controls">
                         </figure>
-                        <p>
-                            The MDS tab features an update button, live entry counters, a sortable and filterable table, and modals
-                            dedicated to certificate decoding and authenticator detail browsing. When the page loads, any
-                            server-provided metadata snapshot is exposed through a hidden bootstrap element so the client can
-                            initialize without an extra network call.
-                        </p>
-                        <p>
-                            The <code>loadMdsData</code> routine checks for forced reloads, applies bootstrap or cached payloads when
-                            available, and otherwise fetches the metadata BLOB with cache-aware options while handling missing files,
-                            clearing caches, and resetting UI state appropriately. Once metadata entries arrive, they are
-                            transformed, indexed by AAGUID, used to populate filter dropdowns, annotated with next-update deadlines,
-                            and reported through the status banner before column resizing is re-enabled.
-                        </p>
-                        <p>
-                            Update requests toggle button states, post to <code>/api/mds/update</code>, interpret whether a reload is
-                            required, and either re-fetch the BLOB or inform the user when data is already current (highlighting
-                            overdue deadlines when necessary). When a credential detail’s AAGUID info button is pressed, the helper
-                            switches to the MDS tab, waits for metadata to load if needed, and then asks the explorer to locate and
-                            highlight the relevant authenticator; the highlighting routine normalizes AAGUIDs, resets filters,
-                            scrolls smoothly to the matching row, and returns whether the focus succeeded.
-                        </p>
                     </div>
-                    <div class="project-section">
-                        <h4>How Authenticator Detail Parameters Are Retrieved</h4>
-                        <figure class="project-figure project-figure-right">
+                    <div class="project-section project-section-split">
+                        <div class="project-section-text">
+                            <h4>How Authenticator Detail Parameters Are Retrieved</h4>
+                            <p>
+                                Clicking an authenticator name stores the active entry (preferring the cached <code>byAaguid</code>
+                                map), scrolls the table row into view, and opens the authenticator modal for focused inspection. The
+                                modal content is generated by <code>buildDetailContent</code>, which reads the metadata statement to
+                                populate overview grids, description and legal headers, schema information, cryptographic strength,
+                                attestation key IDs, UPV values, algorithm families, attachment and matcher hints, display modes, and
+                                user-verification combinations, each rendered as labeled grids or chip lists for clarity.
+                            </p>
+                            <p>
+                                Additional helpers append attestation certificate buttons that launch the certificate decoder modal,
+                                render <code>authenticatorGetInfo</code> fields (including numeric limits, supported versions,
+                                extensions, transports, algorithms, and option flags), and tabulate status reports with formatted dates
+                                and descriptors&mdash;all derived from the metadata entry returned by the MDS payload.
+                            </p>
+                        </div>
+                        <figure class="project-figure">
                             <img src="images/webauthn-project/fido-mds-authenticator-details.png" alt="Authenticator detail modal showing metadata-derived attributes and attestation certificates">
                         </figure>
-                        <p>
-                            Clicking an authenticator name stores the active entry (preferring the cached <code>byAaguid</code>
-                            map), scrolls the table row into view, and opens the authenticator modal for focused inspection. The
-                            modal content is generated by <code>buildDetailContent</code>, which reads the metadata statement to
-                            populate overview grids, description and legal headers, schema information, cryptographic strength,
-                            attestation key IDs, UPV values, algorithm families, attachment and matcher hints, display modes, and
-                            user-verification combinations, each rendered as labeled grids or chip lists for clarity.
-                        </p>
-                        <p>
-                            Additional helpers append attestation certificate buttons that launch the certificate decoder modal,
-                            render <code>authenticatorGetInfo</code> fields (including numeric limits, supported versions,
-                            extensions, transports, algorithms, and option flags), and tabulate status reports with formatted dates
-                            and descriptors&mdash;all derived from the metadata entry returned by the MDS payload.
-                        </p>
                     </div>
                 </div>
             </div>

--- a/style.css
+++ b/style.css
@@ -808,6 +808,10 @@ body.modal-open {
     position: relative;
 }
 
+.project-description-rich .project-section + .project-section {
+    margin-top: clamp(34px, 4vw, 58px);
+}
+
 .project-description-rich .project-section::after {
     content: "";
     display: block;
@@ -816,6 +820,49 @@ body.modal-open {
 
 .project-description-rich .project-section > * + * {
     margin-top: 14px;
+}
+
+.project-description-rich .project-section.project-section-split {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: clamp(28px, 3.5vw, 56px);
+}
+
+.project-description-rich .project-section.project-section-split > * + * {
+    margin-top: 0;
+}
+
+.project-description-rich .project-section-text {
+    flex: 1 1 340px;
+    display: flex;
+    flex-direction: column;
+    gap: clamp(16px, 2vw, 24px);
+}
+
+.project-description-rich .project-section-text > h4 + * {
+    margin-top: 0;
+}
+
+.project-description-rich .project-section-text p {
+    margin: 0;
+    line-height: 1.65;
+}
+
+.project-description-rich .project-section-media {
+    flex: 0 1 min(46%, 560px);
+    display: flex;
+    flex-direction: column;
+    gap: clamp(18px, 2.2vw, 28px);
+}
+
+.project-description-rich .project-section.project-section-split > .project-figure {
+    flex: 0 1 min(46%, 560px);
+}
+
+.project-description-rich .project-section.project-section-split > .project-figure,
+.project-description-rich .project-section-media .project-figure {
+    margin: 0;
 }
 
 .project-description-rich .project-section > p {
@@ -848,7 +895,7 @@ body.modal-open {
 
 .project-description-rich .project-figure {
     margin: 0;
-    width: min(50vw, 640px);
+    width: min(100%, 640px);
 }
 
 .project-description-rich .project-figure img {
@@ -957,6 +1004,19 @@ body.modal-open {
     }
 
     .project-description-rich .project-figure {
+        width: 100%;
+    }
+
+    .project-description-rich .project-section.project-section-split {
+        flex-direction: column;
+        gap: 22px;
+    }
+
+    .project-description-rich .project-section.project-section-split > * {
+        flex: 1 1 auto;
+    }
+
+    .project-description-rich .project-section-media {
         width: 100%;
     }
 


### PR DESCRIPTION
## Summary
- restructure the WebAuthn project description so that each section keeps text on the left and imagery on the right with consistent markup
- add flexbox styling, spacing, and responsive rules to the project sections to avoid the previous cramped alternating layout
- refine figure sizing to keep screenshots aligned and evenly spaced across viewport sizes

## Testing
- none


------
https://chatgpt.com/codex/tasks/task_e_68e0d0ff7d80832c90ae26d882e6cd0d