### PR TITLE
Fix dock intro animation centering

### DIFF
--- a/style.css
+++ b/style.css
@@ -126,31 +126,31 @@ body.intro-prep .intro-photo,
 body.intro-prep #dock {
     opacity: 0;
     filter: blur(10px);
-    transform: translateY(20px);
+    transform: var(--intro-transform-start, translateY(20px));
 }
 
 .intro-target {
     opacity: 0;
     filter: blur(10px);
-    transform: translateY(20px);
+    transform: var(--intro-transform-start, translateY(20px));
 }
 
 @keyframes introFadeUp {
     from {
         opacity: 0;
         filter: blur(10px);
-        transform: translateY(20px);
+        transform: var(--intro-transform-start, translateY(20px));
     }
     to {
         opacity: 1;
         filter: blur(0);
-        transform: translateY(0);
+        transform: var(--intro-transform-end, translateY(0));
     }
 }
 
 body.intro-animate .intro-target {
     animation: introFadeUp 0.9s cubic-bezier(0.34, 1.56, 0.64, 1) forwards;
-    animation-delay: var(0s);
+    animation-delay: var(--intro-delay, 0s);
 }
 
 /* Navigation Bar */
@@ -1336,6 +1336,8 @@ body.dark-mode #introName .txt {
     position: fixed;
     bottom: 58px;
     left: 50%;
+    --intro-transform-start: translateX(-50%) translateY(20px);
+    --intro-transform-end: translateX(-50%) translateY(0);
     transform: translateX(-50%);
     background-color: rgba(255, 255, 255, 0.3);
     backdrop-filter: blur(10px);


### PR DESCRIPTION
## Summary
- allow intro animation transforms to honor element-specific starting positions
- add dock-specific transform variables so it fades in while staying centered after the preloader

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e249653bc8832c99b465409d7ee038